### PR TITLE
Fix Errno 22 `invalid argument` for reading serial devices on ARM PCs

### DIFF
--- a/src/serial/Serial.cpp
+++ b/src/serial/Serial.cpp
@@ -525,8 +525,10 @@ ssize_t Serial::read(void* data, ssize_t size, unsigned long time, bool return_o
 
       FD_ZERO(&fds);
       FD_SET(m_file_descr, &fds);
+      timeval select_timeout = {0,
+                                std::chrono::duration_cast<std::chrono::microseconds>(tz).count()};
       // Look for received data:
-      if ((select_return = select(FD_SETSIZE, &fds, 0, 0, (timeval*)&tz)) > 0)
+      if ((select_return = select(FD_SETSIZE, &fds, 0, 0, &select_timeout)) > 0)
       {
         // LDM("Serial(%s) Select successful.\n", m_dev_name);
         if (return_on_less_data)


### PR DESCRIPTION
## Steps

- [x] Fix the unsafe cast in the `select`'s *timeout* argument
- [x] Test this on a RP4.
- [x] Test this again on an Intel architecture